### PR TITLE
Clean up installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 1. **Install dependencies**: Make sure you have [Bun](https://bun.sh/) installed, then run:
 
-   ```sh
-   ```
 
 2. **Build the UI for production**:
 


### PR DESCRIPTION
Removed empty shell command from installation instructions.

Resolves #75 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
